### PR TITLE
remove invalid package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "ucd-full",
     "version": "16.0.0",
-    "main": "./ucd.js",
     "description": "Encoding the Unicode Character Database as json files",
     "license": "Apache-2.0",
     "keywords": [


### PR DESCRIPTION
There is no ucd.js file, so this `main` field is invalid. I noticed it when running `npx depcheck` on my project.

```
% npx depcheck
Need to install the following packages:
depcheck@1.4.7
Ok to proceed? (y) y
(node:7677) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/brad/src/haohaohow/node_modules/ucd-full/package.json' of './ucd.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
…
```